### PR TITLE
Add get_tokenizations definition (closes #8).

### DIFF
--- a/theano_src/sighan_ner.py
+++ b/theano_src/sighan_ner.py
@@ -203,7 +203,30 @@ def get_data(fn, dict_feature, dict_lex, dict_y, repre, anno, has_label=True):
                 anno,
                 has_label
                 )
+
+
+def get_tokenizations(comm, tool=None):
+    """Returns a flat list of all Tokenization objects in a Communication
+
+    Args:
+        comm (Communication):
+
+    Returns:
+        A list of all Tokenization objects within the Communication
+    """
+    tokenizations = []
+
+    if comm.sectionList:
+        for section in comm.sectionList:
+            if section.sentenceList:
+                for sentence in section.sentenceList:
+                    if sentence.tokenization:
+                        if (tool is None or
+                                sentence.tokenization.metadata.tool == tool):
+                            tokenizations.append(sentence.tokenization)
+    return tokenizations
 	
+
 def read_concrete(comm, no_label=False, mode='char', anno=None):
     #comm = read_communication_from_file(concrete_file)
     tokenizations = get_tokenizations(comm)


### PR DESCRIPTION
In light of the `concrete.inspect` API change I added the `get_tokenizations` definition directly to `sighan_ner.py`.  Sorry for the breaking change!  `get_tokenizations` should be available in `concrete.util` in a future version of concrete-python.